### PR TITLE
misc: Drop allwinner prefix for machines

### DIFF
--- a/conf/machine/bananapi-m64.conf
+++ b/conf/machine/bananapi-m64.conf
@@ -4,5 +4,5 @@
 
 require conf/machine/include/sun50i.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-a64-bananapi-m64.dtb"
+KERNEL_DEVICETREE = "sun50i-a64-bananapi-m64.dtb"
 UBOOT_MACHINE = "bananapi_m64_defconfig"

--- a/conf/machine/nanopi-neo-plus2.conf
+++ b/conf/machine/nanopi-neo-plus2.conf
@@ -6,5 +6,5 @@
 require conf/machine/include/sun50i.inc
 require conf/machine/include/hardware/ap6212a.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo-plus2.dtb"
+KERNEL_DEVICETREE = "sun50i-h5-nanopi-neo-plus2.dtb"
 UBOOT_MACHINE = "nanopi_neo_plus2_defconfig"

--- a/conf/machine/nanopi-neo2.conf
+++ b/conf/machine/nanopi-neo2.conf
@@ -5,5 +5,5 @@
 
 require conf/machine/include/sun50i.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo2.dtb"
+KERNEL_DEVICETREE = "sun50i-h5-nanopi-neo2.dtb"
 UBOOT_MACHINE = "nanopi_neo2_defconfig"

--- a/conf/machine/olinuxino-a64.conf
+++ b/conf/machine/olinuxino-a64.conf
@@ -9,5 +9,5 @@ PREFFERED_VERSION_u-boot = "v2018.09%"
 
 MACHINE_EXTRA_RRECOMMENDS += " linux-firmware-rtl8723"
 
-KERNEL_DEVICETREE = "allwinner/sun50i-a64-olinuxino.dtb"
+KERNEL_DEVICETREE = "sun50i-a64-olinuxino.dtb"
 UBOOT_MACHINE = "a64-olinuxino_defconfig"

--- a/conf/machine/orange-pi-one-plus.conf
+++ b/conf/machine/orange-pi-one-plus.conf
@@ -5,5 +5,5 @@
 
 require conf/machine/include/sun50i-h6.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-h6-orangepi-one-plus.dtb"
+KERNEL_DEVICETREE = "sun50i-h6-orangepi-one-plus.dtb"
 UBOOT_MACHINE = "orangepi_one_plus_defconfig"

--- a/conf/machine/orange-pi-pc2.conf
+++ b/conf/machine/orange-pi-pc2.conf
@@ -4,5 +4,5 @@
 
 require conf/machine/include/sun50i.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-h5-orangepi-pc2.dtb"
+KERNEL_DEVICETREE = "sun50i-h5-orangepi-pc2.dtb"
 UBOOT_MACHINE = "orangepi_pc2_defconfig"

--- a/conf/machine/orange-pi-zero-plus2.conf
+++ b/conf/machine/orange-pi-zero-plus2.conf
@@ -5,5 +5,5 @@
 require conf/machine/include/sun50i.inc
 require conf/machine/include/hardware/ap6212a.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-h5-orangepi-zero-plus2.dtb"
+KERNEL_DEVICETREE = "sun50i-h5-orangepi-zero-plus2.dtb"
 UBOOT_MACHINE = "orangepi_zero_plus2_defconfig"

--- a/conf/machine/orange-pi-zero2.conf
+++ b/conf/machine/orange-pi-zero2.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun50i-h616.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-h616-orangepi-zero2.dtb"
+KERNEL_DEVICETREE = "sun50i-h616-orangepi-zero2.dtb"
 UBOOT_MACHINE = "orangepi_zero2_defconfig"
 
 SPL_BINARY = "u-boot-sunxi-with-spl.bin"

--- a/conf/machine/pine64-plus.conf
+++ b/conf/machine/pine64-plus.conf
@@ -5,5 +5,5 @@
 
 require conf/machine/include/sun50i.inc
 
-KERNEL_DEVICETREE = "allwinner/sun50i-a64-pine64-plus.dtb"
+KERNEL_DEVICETREE = "sun50i-a64-pine64-plus.dtb"
 UBOOT_MACHINE = "pine64_plus_defconfig"


### PR DESCRIPTION
As we have automatic KERNEL_DEVICETREE prefix handling we don't need to add allwinner prefix